### PR TITLE
Add ability to set autocomplete tokens for fields in Contact Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,3 +128,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - withSelect callback clean up
+
+## [3.0.10] - 2022-10-31
+
+### Changed
+- Add ability to set autocomplete tokens for fields in `Contact_Form`

--- a/Formation/Common/Blocks/Contact_Form.php
+++ b/Formation/Common/Blocks/Contact_Form.php
@@ -93,6 +93,7 @@ class Contact_Form {
 				'name'              => ['type' => 'string'],
 				'label'             => ['type' => 'string'],
 				'required'          => ['type' => 'boolean'],
+				'autocomplete'      => ['type' => 'string'],
 				'value'             => ['type' => 'string'],
 				'options'           => ['type' => 'string'],
 				'selected'          => ['type' => 'boolean'],
@@ -113,6 +114,7 @@ class Contact_Form {
 				'name'              => '',
 				'label'             => '',
 				'required'          => false,
+				'autocomplete'      => '',
 				'value'             => '',
 				'options'           => '',
 				'selected'          => false,
@@ -362,6 +364,7 @@ class Contact_Form {
 			'name'              => $name,
 			'label'             => $label,
 			'required'          => $required,
+			'autocomplete'      => $autocomplete,
 			'value'             => $value,
 			'options'           => $options,
 			'selected'          => $selected,
@@ -425,6 +428,10 @@ class Contact_Form {
 
 		if ( $required ) {
 			$attr['aria-required'] = 'true';
+		}
+
+		if ( $autocomplete ) {
+			$attr['autocomplete'] = $autocomplete;
 		}
 
 		if ( $rows && 'textarea' === $type ) {

--- a/Formation/Common/assets/src/blocks/contact-form/field.js
+++ b/Formation/Common/assets/src/blocks/contact-form/field.js
@@ -78,6 +78,7 @@ registerBlockType(name, {
       name = def.name,
       label = def.label,
       required = def.required,
+      autocomplete = def.autocomplete,
       value = def.value,
       options = def.options,
       selected = def.selected,
@@ -269,6 +270,11 @@ registerBlockType(name, {
                 { label: typeLabels.select, value: 'select' }
               ]}
               onChange={type => setAttributes({ type })}
+            />
+            <TextControl
+              label='Autocomplete Token(s)'
+              value={autocomplete}
+              onChange={autocomplete => setAttributes({ autocomplete })}
             />
             {rowsInput}
             {placeholderInput}


### PR DESCRIPTION
This PR allows content authors to comply with [WCAG Success Criterion 1.3.5: Identify Input Purpose](https://www.w3.org/TR/WCAG21/#identify-input-purpose) by setting autocomplete tokens through the admin panel. It is done with a text input because there can be multiple tokens for each field, and [they can be arbitrarily named](https://html.spec.whatwg.org/#autofill).